### PR TITLE
implement predefined palette as option

### DIFF
--- a/demo/fixedpalette.html
+++ b/demo/fixedpalette.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<title>RgbQuant.js fixed palette example</title>
+
+	<script src="../src/rgbquant.js"></script>
+
+	<script>
+		var rgb3level = [
+			[0,0,0],
+			[128,128,128],
+			[255,255,255],
+			[128,0,0],
+			[255,0,0],
+			[255,128,128],
+			[255,128,0],
+			[128,128,0],
+			[128,255,0],
+			[255,255,0],
+			[255,255,128],
+			[0,128,0],
+			[0,255,0],
+			[128,255,128],
+			[0,255,128],
+			[0,128,128],
+			[0,255,255],
+			[128,255,255],
+			[0,128,255],
+			[0,0,128],
+			[0,0,255],
+			[128,128,255],
+			[128,0,128],
+			[128,0,255],
+			[255,0,255],
+			[255,128,255],
+			[255,0,128]
+		];
+
+		var q = new RgbQuant({
+			palette: rgb3level,
+			dithKern: "FloydSteinberg",
+		});
+
+		window.onload = function() {
+			var img = document.getElementById("moo");
+			var thing = q.reduce(img);
+
+			var can = document.createElement("canvas");
+			can.width = img.naturalWidth;
+			can.height = img.naturalHeight;
+			var ctx = can.getContext("2d");
+			var imgd = ctx.createImageData(can.width,can.height);
+			imgd.data.set(thing);
+			ctx.putImageData(imgd,0,0);
+
+			document.body.appendChild(can);
+		};
+	</script>
+</head>
+<body>
+	<img id="moo" src="img/photoman.jpg" alt="">
+</body>
+</html>

--- a/src/rgbquant.js
+++ b/src/rgbquant.js
@@ -45,7 +45,7 @@
 		// accumulated histogram
 		this.histogram = {};
 		// palette - rgb triplets
-		this.idxrgb = [];
+		this.idxrgb = opts.palette || [];
 		// palette - int32 vals
 		this.idxi32 = [];
 		// reverse lookup {i32:idx}
@@ -54,6 +54,24 @@
 		this.i32i32 = {};
 		// {i32:rgb}
 		this.i32rgb = {};
+
+		// if pre-defined palette, build lookups
+		if (this.idxrgb.length > 0) {
+			var self = this;
+			this.idxrgb.forEach(function(rgb, i) {
+				var i32 =
+					(255    << 24) |	// alpha
+					(rgb[2] << 16) |	// blue
+					(rgb[1] <<  8) |	// green
+					 rgb[0];			// red
+
+				self.idxi32[i]		= i32;
+				self.i32idx[i32]	= i;
+				self.i32rgb[i32]	= rgb;
+			});
+
+			this.palLocked = true;
+		}
 	}
 
 	// gathers histogram info
@@ -70,6 +88,7 @@
 	};
 
 	// image quantizer
+	// todo: memoize colors here also
 	// @retType: 1 - Uint8Array (default), 2 - Indexed array, 3 - Match @img type (unimplemented, todo)
 	RgbQuant.prototype.reduce = function reduce(img, retType, dithKern, dithSerp) {
 		if (!this.palLocked)


### PR DESCRIPTION
Hey, noticed your fork. thought you might be interested in this update which implements fixed palettes.

It's a _huge_ speed boost because RgbQuant spends a lot of time doing color analysis/selection for optimal palette reduction. If you already have a predefined palette (as it seems in your SMS case), you can skip the expensive `.sample()` and `.palette()` building steps completely and just use `reduce()`. See included sample.

cheers!
Leon
