### PR TITLE
Implement command line interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+/*.png

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('fs');
+const _ = require('underscore');
 
 const Canvas = require('canvas');
 const Image = Canvas.Image;
@@ -134,16 +135,9 @@ if (require.main === module) {
 		.help()
 		.argv;
 		
-	console.log('commandLine', commandLine);
-	
 	if (commandLine._.includes('convert')) {
-		convert(commandLine.src, commandLine.dest, {
-			colors: 16,
-			paletteCount: 1,
-			maxTiles: 256,
-			minHueCols: 0,
-			weighPopularity: true
-		});
+		const options = _.pick(commandLine, 'colors', 'maxTiles', 'minHueCols', 'dithKern', 'dithSerp', 'weighPopularity', 'weighEntropy');
+		convert(commandLine.src, commandLine.dest, options);
 	}
 }
 

--- a/index.js
+++ b/index.js
@@ -5,6 +5,41 @@ const Image = Canvas.Image;
 
 const { RgbQuantSMS } = require('./src/rgbquant-sms');
 
+function drawPixels(idxi8, width0, width1) {
+	var idxi32 = new Uint32Array(idxi8.buffer);
+
+	width1 = width1 || width0;
+
+	const canvasWidth = width0;
+	const canvasHeight = Math.ceil(idxi32.length / width0);
+
+	var can = new Canvas.Canvas(canvasWidth, canvasHeight),
+		can2 = new Canvas.Canvas(canvasWidth, canvasHeight),
+		ctx = can.getContext("2d"),
+		ctx2 = can2.getContext("2d");
+
+	ctx.imageSmoothingEnabled = ctx.mozImageSmoothingEnabled = ctx.webkitImageSmoothingEnabled = ctx.msImageSmoothingEnabled = false;
+	ctx2.imageSmoothingEnabled = ctx2.mozImageSmoothingEnabled = ctx2.webkitImageSmoothingEnabled = ctx2.msImageSmoothingEnabled = false;
+
+	var imgd = ctx.createImageData(can.width, can.height);
+
+	var buf32 = new Uint32Array(imgd.data.buffer);
+	buf32.set(idxi32);
+
+	ctx.putImageData(imgd, 0, 0);
+
+	ctx2.drawImage(can, 0, 0, can2.width, can2.height);
+
+	return can2;
+}
+
+const tileMapToCanvas = tileMap => {
+	var image = new RgbQuantSMS.IndexedImage(tileMap.mapW * 8, tileMap.mapH * 8, tileMap.palettes);
+	image.drawMap(tileMap);
+	var	ican = drawPixels(image.toRgbBytes(), image.width);
+	return ican;
+}
+
 const convert = async (src, options) => {
 	const quant = new RgbQuantSMS(options);
 
@@ -25,6 +60,9 @@ const convert = async (src, options) => {
 	
 	const reducedTileMap = quant.convert(canvas);
 	console.log('reducedTileMap', { reducedTileMap, tileCount: reducedTileMap.tiles.length });
+	
+	const outCanvas = tileMapToCanvas(reducedTileMap);
+	console.log('outCanvas', outCanvas);
 }
 
 /* if called directly from command line or from a shell script */

--- a/index.js
+++ b/index.js
@@ -22,15 +22,8 @@ const commandLine = yargs.scriptName('rgbquant-sms')
 	
 console.log('commandLine', commandLine);
 
-(async () => {
-	
-	const quant = new RgbQuantSMS({
-		colors: 16,
-		paletteCount: 1,
-		maxTiles: 256,
-		minHueCols: 0,
-		weighPopularity: true
-	});
+const convert = async (src, options) => {
+	const quant = new RgbQuantSMS(options);
 
 	const getCanvas = async (src) => new Promise((resolve, reject) => {
 		const img = new Image();
@@ -45,9 +38,18 @@ console.log('commandLine', commandLine);
 		img.src = src;
 	});
 
-	const canvas = await getCanvas('demo/img/biking.jpg');
+	const canvas = await getCanvas(src);
 	
 	const reducedTileMap = quant.convert(canvas);
-	
-	//console.log('reducedTileMap', { reducedTileMap, tileCount: reducedTileMap.tiles.length });
+	console.log('reducedTileMap', { reducedTileMap, tileCount: reducedTileMap.tiles.length });
+}
+
+(async () => {
+	convert('demo/img/biking.jpg', {
+		colors: 16,
+		paletteCount: 1,
+		maxTiles: 256,
+		minHueCols: 0,
+		weighPopularity: true
+	});	
 })();

--- a/index.js
+++ b/index.js
@@ -3,7 +3,24 @@
 const Canvas = require('canvas');
 const Image = Canvas.Image;
 
+const yargs = require('yargs');
+
 const { RgbQuantSMS } = require('./src/rgbquant-sms');
+
+const commandLine = yargs.scriptName('rgbquant-sms')
+	.usage('$0 <cmd> [args]')
+	.command('convert <src>', 'Converts an image into a png with the tile count reduced', (yargs) => {
+		yargs.positional('src', {
+			type: 'string',
+			describe: 'The source image, the one that will be converted'
+		});
+	})
+	.demandCommand(1, 'You need to inform at least one command before moving on')
+	.strict()
+	.help()
+	.argv;
+	
+console.log('commandLine', commandLine);
 
 (async () => {
 	
@@ -32,5 +49,5 @@ const { RgbQuantSMS } = require('./src/rgbquant-sms');
 	
 	const reducedTileMap = quant.convert(canvas);
 	
-	console.log('reducedTileMap', { reducedTileMap, tileCount: reducedTileMap.tiles.length });
+	//console.log('reducedTileMap', { reducedTileMap, tileCount: reducedTileMap.tiles.length });
 })();

--- a/index.js
+++ b/index.js
@@ -3,24 +3,7 @@
 const Canvas = require('canvas');
 const Image = Canvas.Image;
 
-const yargs = require('yargs');
-
 const { RgbQuantSMS } = require('./src/rgbquant-sms');
-
-const commandLine = yargs.scriptName('rgbquant-sms')
-	.usage('$0 <cmd> [args]')
-	.command('convert <src>', 'Converts an image into a png with the tile count reduced', (yargs) => {
-		yargs.positional('src', {
-			type: 'string',
-			describe: 'The source image, the one that will be converted'
-		});
-	})
-	.demandCommand(1, 'You need to inform at least one command before moving on')
-	.strict()
-	.help()
-	.argv;
-	
-console.log('commandLine', commandLine);
 
 const convert = async (src, options) => {
 	const quant = new RgbQuantSMS(options);
@@ -44,12 +27,34 @@ const convert = async (src, options) => {
 	console.log('reducedTileMap', { reducedTileMap, tileCount: reducedTileMap.tiles.length });
 }
 
-(async () => {
-	convert('demo/img/biking.jpg', {
-		colors: 16,
-		paletteCount: 1,
-		maxTiles: 256,
-		minHueCols: 0,
-		weighPopularity: true
-	});	
-})();
+/* if called directly from command line or from a shell script */
+if (require.main === module) {
+	const yargs = require('yargs');
+
+	const commandLine = yargs.scriptName('rgbquant-sms')
+		.usage('$0 <cmd> [args]')
+		.command('convert <src>', 'Converts an image into a png with the tile count reduced', (yargs) => {
+			yargs.positional('src', {
+				type: 'string',
+				describe: 'The source image, the one that will be converted'
+			});
+		})
+		.demandCommand(1, 'You need to inform at least one command before moving on')
+		.strict()
+		.help()
+		.argv;
+		
+	console.log('commandLine', commandLine);
+	
+	if (commandLine._.includes('convert')) {
+		convert(commandLine.src, {
+			colors: 16,
+			paletteCount: 1,
+			maxTiles: 256,
+			minHueCols: 0,
+			weighPopularity: true
+		});
+	}
+}
+
+module.exports = { RgbQuantSMS, convert };

--- a/index.js
+++ b/index.js
@@ -5,8 +5,6 @@ const Image = Canvas.Image;
 
 const { RgbQuantSMS } = require('./src/rgbquant-sms');
 
-console.log('Canvas', Canvas);
-
 (async () => {
 	
 	const quant = new RgbQuantSMS({
@@ -31,11 +29,9 @@ console.log('Canvas', Canvas);
 	});
 
 	const canvas = await getCanvas('demo/img/biking.jpg');
-	console.log('canvas', canvas);
 	
 	quant.sample(canvas);
 	const palettes = quant.palettes();
-	console.log('palettes', palettes)
 
 	const unoptimizedTileMap = quant.reduceToTileMap(canvas);
 	const optimizedTileMap = quant.normalizeTiles(unoptimizedTileMap);

--- a/index.js
+++ b/index.js
@@ -30,14 +30,7 @@ const { RgbQuantSMS } = require('./src/rgbquant-sms');
 
 	const canvas = await getCanvas('demo/img/biking.jpg');
 	
-	quant.sample(canvas);
-	const palettes = quant.palettes();
-
-	const unoptimizedTileMap = quant.reduceToTileMap(canvas);
-	const optimizedTileMap = quant.normalizeTiles(unoptimizedTileMap);
-	quant.updateTileEntropy(optimizedTileMap.tiles);
-	const similarTiles = quant.groupBySimilarity(optimizedTileMap);
-	const reducedTileMap = quant.removeSimilarTiles(optimizedTileMap, similarTiles);
+	const reducedTileMap = quant.convert(canvas);
 	
 	console.log('reducedTileMap', { reducedTileMap, tileCount: reducedTileMap.tiles.length });
 })();

--- a/index.js
+++ b/index.js
@@ -80,14 +80,54 @@ if (require.main === module) {
 	const commandLine = yargs.scriptName('rgbquant-sms')
 		.usage('$0 <cmd> [args]')
 		.command('convert <src> <dest>', 'Converts an image into a png with the tile count reduced', (yargs) => {
-			yargs.positional('src', {
-				type: 'string',
-				describe: 'The source image, the one that will be converted'
-			});
-			yargs.positional('dest', {
-				type: 'string',
-				describe: 'The destination image that will be generated'
-			});
+			yargs
+				.positional('src', {
+					type: 'string',
+					describe: 'The source image, the one that will be converted'
+				})
+				.positional('dest', {
+					type: 'string',
+					describe: 'The destination image that will be generated'
+				})
+				.options({
+					'colors': {
+						default: 16,
+						describe: 'Desired palette size',
+						type: 'integer'
+					},
+					'max-tiles': {
+						default: 256,
+						describe: 'Maximum number of tiles to use',
+						type: 'integer'
+					},
+					'min-hue-cols': {
+						default: 512,
+						describe: 'Number of colors per hue group to evaluate regardless of counts, to retain low-count hues',
+						type: 'integer'
+					},
+					'dithKern': {
+						default: '',
+						describe: 'Dithering kernel name; can one of these:\n' +
+								'FloydSteinberg, Stucki, Atkinson, Jarvis, Burkes, Sierra, TwoSierra, SierraLite, ' +
+								'FalseFloydSteinberg, Ordered2, Ordered2x1, Ordered3, Ordered4 or Ordered8',
+						type: 'string'
+					},
+					'dith-serp': {
+						default: false,
+						describe: 'Enable serpentine pattern dithering',
+						type: 'boolean'
+					},
+					'weigh-popularity': {
+						default: true,
+						describe: 'Weigh by popularity when reducing tile count',
+						type: 'boolean'
+					},
+					'weigh-entropy': {
+						default: false,
+						describe: 'Weigh by entropy when reducing tile count',
+						type: 'boolean'
+					}					
+				});
 		})
 		.demandCommand(1, 'You need to inform at least one command before moving on')
 		.strict()

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const fs = require('fs');
+
 const Canvas = require('canvas');
 const Image = Canvas.Image;
 
@@ -63,6 +65,9 @@ const convert = async (src, options) => {
 	
 	const outCanvas = tileMapToCanvas(reducedTileMap);
 	console.log('outCanvas', outCanvas);
+	
+	const buffer = outCanvas.toBuffer('image/png');
+	fs.writeFileSync('./image.png', buffer);
 }
 
 /* if called directly from command line or from a shell script */

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "canvas": "^2.11.2",
+        "underscore": "^1.13.6",
         "yargs": "^17.7.2"
       }
     },
@@ -670,6 +671,11 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
+    "node_modules/underscore": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -1231,6 +1237,11 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "underscore": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "rgbquant-sms",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rgbquant-sms",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
-        "canvas": "^2.11.2"
+        "canvas": "^2.11.2",
+        "yargs": "^17.7.2"
       }
     },
     "node_modules/@mapbox/node-pre-gyp": {
@@ -53,6 +54,20 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/aproba": {
@@ -107,6 +122,35 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/color-support": {
       "version": "1.1.3",
@@ -171,6 +215,14 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
@@ -215,6 +267,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/glob": {
@@ -463,6 +523,14 @@
         "node": ">= 6"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -629,15 +697,64 @@
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "engines": {
+        "node": ">=12"
+      }
     }
   },
   "dependencies": {
@@ -674,6 +791,14 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
     },
     "aproba": {
       "version": "2.0.0",
@@ -717,6 +842,29 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
+    },
+    "cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "color-support": {
       "version": "1.1.3",
@@ -764,6 +912,11 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+    },
     "fs-minipass": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
@@ -802,6 +955,11 @@
         "strip-ansi": "^6.0.1",
         "wide-align": "^1.1.2"
       }
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "glob": {
       "version": "7.2.3",
@@ -979,6 +1137,11 @@
         "util-deprecate": "^1.0.1"
       }
     },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
+    },
     "rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -1096,15 +1259,49 @@
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
+    "y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+    },
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "requires": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      }
+    },
+    "yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/haroldo-ok/RgbQuant-SMS.js#readme",
   "dependencies": {
-    "canvas": "^2.11.2"
+    "canvas": "^2.11.2",
+    "yargs": "^17.7.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://github.com/haroldo-ok/RgbQuant-SMS.js#readme",
   "dependencies": {
     "canvas": "^2.11.2",
+    "underscore": "^1.13.6",
     "yargs": "^17.7.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rgbquant-sms",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "RgbQuant.js adapted for quantizing images for the Sega Master System hardware",
   "main": "index.js",
   "scripts": {

--- a/src/rgbquant-sms.js
+++ b/src/rgbquant-sms.js
@@ -615,6 +615,18 @@
 		};
 	}
 	
+	RgbQuantSMS.prototype.convert = function(img) {
+		this.sample(img);
+		const palettes = this.palettes();
+
+		const unoptimizedTileMap = this.reduceToTileMap(img);
+		const optimizedTileMap = this.normalizeTiles(unoptimizedTileMap);
+		this.updateTileEntropy(optimizedTileMap.tiles);
+		const similarTiles = this.groupBySimilarity(optimizedTileMap);
+		const reducedTileMap = this.removeSimilarTiles(optimizedTileMap, similarTiles);
+		
+		return reducedTileMap;
+	}
 	
 	//-------------------
 	


### PR DESCRIPTION
Implemented command line interface; now, the application can be called either from command line, from browser or as a node.js module.

Help message:
```
rgbquant-sms convert <src> <dest>

Converts an image into a png with the tile count reduced

Positionals:
  src   The source image, the one that will be converted     [string] [required]
  dest  The destination image that will be generated         [string] [required]

Options:
  --version           Show version number                              [boolean]
  --help              Show help                                        [boolean]
  --colors            Desired palette size                         [default: 16]
  --max-tiles         Maximum number of tiles to use              [default: 256]
  --min-hue-cols      Number of colors per hue group to evaluate regardless of
                      counts, to retain low-count hues            [default: 512]
  --dithKern          Dithering kernel name; can one of these:
                      FloydSteinberg, Stucki, Atkinson, Jarvis, Burkes, Sierra,
                      TwoSierra, SierraLite, FalseFloydSteinberg, Ordered2,
                      Ordered2x1, Ordered3, Ordered4 or Ordered8
                                                          [string] [default: ""]
  --dith-serp         Enable serpentine pattern dithering
                                                      [boolean] [default: false]
  --weigh-popularity  Weigh by popularity when reducing tile count
                                                       [boolean] [default: true]
  --weigh-entropy     Weigh by entropy when reducing tile count
                                                      [boolean] [default: false]
```