### PR TITLE
Configure to run as a `npm` command named `rgbquant-sms`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 'use strict';
 
 const fs = require('fs');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,20 @@
 {
   "name": "rgbquant-sms",
-  "version": "0.0.3",
+  "version": "0.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rgbquant-sms",
-      "version": "0.0.3",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "canvas": "^2.11.2",
         "underscore": "^1.13.6",
         "yargs": "^17.7.2"
+      },
+      "bin": {
+        "rgbquant-sms": "index.js"
       }
     },
     "node_modules/@mapbox/node-pre-gyp": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   },
   "author": "",
   "license": "MIT",
+  "bin": {
+    "rgbquant-sms": "./index.js"
+  },
   "bugs": {
     "url": "https://github.com/haroldo-ok/RgbQuant-SMS.js/issues"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rgbquant-sms",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "RgbQuant.js adapted for quantizing images for the Sega Master System hardware",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Now, if installed as a package, it will be possible to call the tool as `rgbquant-sms`.